### PR TITLE
chore: update build scripts for esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "scripts": {
     "commit": "git-cz",
     "test-i18n": "jasmine-node i18n/spec",
-    "test-i18n-ucd": "jasmine-node i18n/ucd/spec"
+    "test-i18n-ucd": "jasmine-node i18n/ucd/spec",
+    "build": "npx -y esbuild src/Angular.js --bundle --outfile=dist/angular.js",
+    "build:min": "npx -y esbuild src/Angular.js --bundle --minify --outfile=dist/angular.min.js"
   },
   "devDependencies": {
     "angular-benchpress": "0.x.x",


### PR DESCRIPTION
## Summary
- remove invalid separator from esbuild build scripts so bundling works

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run build:min`


------
https://chatgpt.com/codex/tasks/task_b_68a8c69a692083219cb2d677b1958987