### PR TITLE
ci: add docs workflow for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - $default-branch
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.19.4
+      - name: Use npm 11.4.2
+        run: npm install -g npm@11.4.2
+      - name: Install dependencies
+        run: npm ci
+      - name: Build docs
+        run: npx gulp --gulpfile docs/gulpfile.js
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/docs
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- build AngularJS docs and publish to GitHub Pages on master/main/default branch updates

## Testing
- `npm install --no-save`
- `npm test` *(fails: Cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_b_68aa1f21fb208321a2f9214cf42373d7