### PR TITLE
fix(input): preserve datetime-local milliseconds

### DIFF
--- a/test/ng/directive/inputSpec.js
+++ b/test/ng/directive/inputSpec.js
@@ -1499,6 +1499,18 @@ describe('input', function() {
       expect(inputElm.val()).toBe('1970-01-01T15:41:00.500');
 
       $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 50);
+      });
+
+      expect(inputElm.val()).toBe('1970-01-01T15:41:50.050');
+
+      $rootScope.$apply(function() {
+        $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 0, 50);
+      });
+
+      expect(inputElm.val()).toBe('1970-01-01T15:41:00.050');
+
+      $rootScope.$apply(function() {
         $rootScope.threeFortyOnePm = new Date(1970, 0, 1, 15, 41, 50, 0);
       });
 


### PR DESCRIPTION
## Summary
- ensure time inputs keep three-digit millisecond precision even when the browser trims trailing zeros
- respect `timeSecondsFormat` and `timeStripZeroSeconds` without losing milliseconds
- add regression tests for zero-padded milliseconds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68acd6bc43e483218cd296fbdb9e221d