### PR TITLE
fix(docs): copy aria and message-format modules

### DIFF
--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -39,7 +39,9 @@ function copyAngular() {
     'angular-sanitize',
     'angular-touch',
     'angular-animate',
-    'angular-mocks'
+    'angular-mocks',
+    'angular-aria',
+    'angular-message-format'
   ];
 
   for (const mod of modules) {


### PR DESCRIPTION
## Summary
- include angular-aria and angular-message-format in docs build output so examples load required modules

## Testing
- `npm run build`
- `npm run docs`
- `npm run test:e2e` *(fails: 9)*

------
https://chatgpt.com/codex/tasks/task_b_68b4af5841888321b547d75cbd120911