### PR TITLE
fix(docs): use hashbang links and anchor scrolling

### DIFF
--- a/docs/app/assets/Error404.html
+++ b/docs/app/assets/Error404.html
@@ -6,6 +6,6 @@
 
   <dl ng-repeat="(key, value) in results" ng-show="value.length" style="float: left; margin-right:20px">
     <dt>{{ key }}</dt>
-    <dd ng-repeat="item in value"><a ng-href="{{ item.path }}">{{ item.name }}</a></dd>
+    <dd ng-repeat="item in value"><a ng-href="#!/{{ item.path }}">{{ item.name }}</a></dd>
   </dl>
 </div>

--- a/docs/app/e2e/table-of-contents.scenario.js
+++ b/docs/app/e2e/table-of-contents.scenario.js
@@ -127,4 +127,20 @@ describe('table of contents', function() {
       expect(match[1].all(by.css('li')).count()).toBe(3);
     });
   });
+
+  it('should navigate to the correct section when a TOC link is clicked', function() {
+    browser.get('build/docs/index.html#!/guide/services');
+
+    var tocLinks = element.all(by.css('toc-container > div > toc-tree a'));
+    tocLinks.get(1).getAttribute('href').then(function(href) {
+      var id = href.split('#').pop();
+      tocLinks.get(1).click();
+      browser.waitForAngular();
+      expect(browser.getCurrentUrl()).toContain('#!/guide/services#' + id);
+      browser.executeScript('return document.getElementById(arguments[0]).getBoundingClientRect().top;', id)
+        .then(function(top) {
+          expect(top).toBeLessThan(20);
+        });
+    });
+  });
 });

--- a/docs/app/src/directives.js
+++ b/docs/app/src/directives.js
@@ -91,7 +91,7 @@ directivesModule
 .component('tocTree', {
   template: '<ul>' +
       '<li ng-repeat="item in $ctrl.items">' +
-        '<a ng-href="{{ $ctrl.path }}#{{item.fragment}}">{{item.title}}</a>' +
+        '<a ng-href="#!/{{ $ctrl.path }}#{{item.fragment}}">{{item.title}}</a>' +
         '<toc-tree ng-if="::item.children.length > 0" items="item.children"></toc-tree>' +
       '</li>' +
     '</ul>',

--- a/docs/app/src/docs.js
+++ b/docs/app/src/docs.js
@@ -3,9 +3,9 @@
 angular.module('DocsController', ['currentVersionData'])
 
 .controller('DocsController', [
-          '$scope', '$rootScope', '$location', '$window', '$cookies',
+          '$scope', '$rootScope', '$location', '$window', '$cookies', '$anchorScroll',
               'NG_PAGES', 'NG_NAVIGATION', 'CURRENT_NG_VERSION',
-  function($scope, $rootScope, $location, $window, $cookies,
+  function($scope, $rootScope, $location, $window, $cookies, $anchorScroll,
               NG_PAGES, NG_NAVIGATION, CURRENT_NG_VERSION) {
 
   var errorPartialPath = 'Error404.html';
@@ -22,6 +22,7 @@ angular.module('DocsController', ['currentVersionData'])
     var pagePath = $scope.currentPage ? $scope.currentPage.path : $location.path();
     $window._gaq.push(['_trackPageview', pagePath]);
     $scope.loading = false;
+    $anchorScroll();
   });
 
   $scope.$on('$includeContentError', function() {

--- a/docs/app/src/tutorials.js
+++ b/docs/app/src/tutorials.js
@@ -13,10 +13,10 @@ angular.module('tutorials', [])
   return {
     scope: {},
     template:
-      '<a ng-href="tutorial/{{prev}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-step-backward"></i> Previous</li></a>\n' +
+      '<a ng-href="#!/tutorial/{{prev}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-step-backward"></i> Previous</li></a>\n' +
       '<a ng-href="http://angular.github.io/angular-phonecat/step-{{seq}}/app"><li class="btn btn-primary"><i class="glyphicon glyphicon-play"></i> Live Demo</li></a>\n' +
       '<a ng-href="https://github.com/angular/angular-phonecat/compare/step-{{diffLo}}...step-{{diffHi}}"><li class="btn btn-primary"><i class="glyphicon glyphicon-search"></i> Code Diff</li></a>\n' +
-      '<a ng-href="tutorial/{{next}}"><li class="btn btn-primary">Next <i class="glyphicon glyphicon-step-forward"></i></li></a>',
+      '<a ng-href="#!/tutorial/{{next}}"><li class="btn btn-primary">Next <i class="glyphicon glyphicon-step-forward"></i></li></a>',
     link: function(scope, element, attrs) {
       var seq = 1 * attrs.docTutorialNav;
       scope.seq = seq;

--- a/docs/app/test/docsSpec.js
+++ b/docs/app/test/docsSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('DocsController', function() {
-  var $scope;
+  var $scope, $anchorScroll;
 
   angular.module('fake', [])
     .value('$cookies', {})
@@ -14,7 +14,11 @@ describe('DocsController', function() {
   angular.module('allVersionsData', [])
     .value('ALL_NG_VERSIONS', {});
 
-  beforeEach(module('fake', 'DocsController'));
+  beforeEach(module('fake', 'DocsController', function($provide) {
+    $anchorScroll = jasmine.createSpy('$anchorScroll');
+    $provide.value('$anchorScroll', $anchorScroll);
+  }));
+
   beforeEach(inject(function($rootScope, $controller) {
     $scope = $rootScope;
     $controller('DocsController', { $scope: $scope });
@@ -36,6 +40,11 @@ describe('DocsController', function() {
       $scope.$broadcast('$includeContentLoaded');
       expect($window._gaq.pop()).toEqual(['_trackPageview', 'x/y/z']);
     }));
+
+    it('should scroll to the anchor', function() {
+      $scope.$broadcast('$includeContentLoaded');
+      expect($anchorScroll).toHaveBeenCalled();
+    });
   });
 
   it('should hide the loading indicator after content is loaded', inject(function($compile) {


### PR DESCRIPTION
## Summary
- prefix internal doc links with `#!` to avoid HTML5 routing issues
- scroll to anchors after content loads with `$anchorScroll`
- test TOC navigation for correct section scrolling

## Testing
- `npx eslint docs/app/src/docs.js docs/app/src/directives.js docs/app/src/tutorials.js docs/app/test/docsSpec.js docs/app/e2e/table-of-contents.scenario.js`
- `npm run lint` *(fails: Unexpected constant condition & `msie` redeclaration)*
- `npm test`
- `npm run docs`
- `npm run test:e2e` *(fails: Could not find chromedriver)*

------
https://chatgpt.com/codex/tasks/task_b_68bf2e50dc908321bea7161821107a33