### PR TITLE
test(strict-mode): ensure runtime functions execute in strict context

### DIFF
--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -1,6 +1,10 @@
+/* eslint strict: "off" */
+/* eslint-disable no-constant-condition */
+
+'use strict';
+
 // This file has many tests which read nicely if constant conditions
 // are used.
-/* eslint-disable no-constant-condition */
 
 describe('parser', function () {
   describe('lexer', function () {

--- a/test/ng/rootScopeSpec.js
+++ b/test/ng/rootScopeSpec.js
@@ -1,3 +1,7 @@
+/* eslint strict: "off" */
+
+'use strict';
+
 describe('Scope', function () {
   beforeEach(module(provideLog));
 


### PR DESCRIPTION
## Summary
- restore `'use strict'` directives in critical unit tests so functions returned by other functions run without global context
- disable ESLint strict rule for these files to keep linter passing

## Testing
- `npm run lint`
- `npm run docs`
- `npm run test`
- `npm run test:e2e` *(fails: Could not find chromedriver)*


------
https://chatgpt.com/codex/tasks/task_b_68c5f2c731948321865ddcd2b86467a2