### PR TITLE
docs: serve default docs index using production deployment

### DIFF
--- a/docs/config/services/deployments/default.js
+++ b/docs/config/services/deployments/default.js
@@ -1,39 +1,16 @@
 'use strict';
 
+var productionDeployment = require('./production');
+
 module.exports = function defaultDeployment(getVersion) {
-  return {
-    name: 'default',
-    examples: {
-      commonFiles: {
-        scripts: ['../../angular.min.js']
-      },
-      dependencyPath: '../../'
-    },
-    scripts: [
-      'angular.min.js',
-      'angular-resource.min.js',
-      'angular-route.min.js',
-      'angular-cookies.min.js',
-      'angular-sanitize.min.js',
-      'angular-touch.min.js',
-      'angular-animate.min.js',
-      'components/marked-' + getVersion('marked') + '/marked.min.js',
-      'js/angular-bootstrap/dropdown-toggle.min.js',
-      'components/lunr-' + getVersion('lunr') + '/lunr.min.js',
-      'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/prettify.js',
-      'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/lang-css.js',
-      'js/current-version-data.js',
-      'js/all-versions-data.js',
-      'js/pages-data.js',
-      'js/nav-data.js',
-      'js/docs.min.js'
-    ],
-    stylesheets: [
-      'components/bootstrap-' + getVersion('bootstrap') + '/css/bootstrap.min.css',
-      'css/prettify-theme.css',
-      'css/angular-topnav.css',
-      'css/docs.css',
-      'css/animations.css'
-    ]
-  };
+  var deployment = productionDeployment(getVersion);
+
+  // The default deployment is what generates `index.html`. It previously referenced
+  // locally built AngularJS artifacts, which are not available when the docs are
+  // served from GitHub Pages. By basing the default deployment on the production
+  // configuration we ensure the generated `index.html` uses CDN URLs and behaves
+  // like `index-production.html`.
+  deployment.name = 'default';
+
+  return deployment;
 };


### PR DESCRIPTION
## Summary
- generate default docs index from production deployment to work on GitHub Pages

## Testing
- `npm run prettier`
- `npm run lint`
- `npm run test`
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_b_68c73b4720a88321bc57292e6f9d096d