### PR TITLE
docs(build): align index with production deployment

### DIFF
--- a/docs/config/index.js
+++ b/docs/config/index.js
@@ -171,10 +171,9 @@ module.exports = new Package('angularjs', [
     ) {
       generateIndexPagesProcessor.deployments = [
         debugDeployment,
-        defaultDeployment,
+        productionDeployment,
         jqueryDeployment,
-        testDeployment,
-        productionDeployment
+        testDeployment
       ];
 
       generateProtractorTestsProcessor.deployments = [defaultDeployment, jqueryDeployment];

--- a/docs/config/processors/index-page.js
+++ b/docs/config/processors/index-page.js
@@ -34,7 +34,7 @@ module.exports = function generateIndexPagesProcessor() {
           deployment
         );
 
-        indexDoc.id = 'index' + (deployment.name === 'default' ? '' : '-' + deployment.name);
+        indexDoc.id = 'index' + (deployment.name === 'production' ? '' : '-' + deployment.name);
 
         docs.push(indexDoc);
       });

--- a/docs/config/services/deployments/production.js
+++ b/docs/config/services/deployments/production.js
@@ -1,45 +1,29 @@
 'use strict';
 
-var versionInfo = require('../../../../lib/versions/version-info');
-
-var googleCdnUrl = '//ajax.googleapis.com/ajax/libs/angularjs/';
-var angularCodeUrl = '//code.angularjs.org/';
-
-var cdnUrl = googleCdnUrl + versionInfo.cdnVersion;
-
-// The "examplesDependencyPath" here applies to the examples when they are opened in plnkr.co.
-// The embedded examples instead always include the files from the *default* deployment,
-// to ensure that the source files are always available.
-// The plnkr examples must always use the code.angularjs.org source files.
-// We cannot rely on the CDN files here, because they are not deployed by the time
-// docs.angularjs.org and code.angularjs.org need them.
-var versionPath = versionInfo.currentVersion.isSnapshot ? 'snapshot' : versionInfo.currentVersion.version;
-var examplesDependencyPath = angularCodeUrl + versionPath + '/';
-
 module.exports = function productionDeployment(getVersion) {
   return {
     name: 'production',
     examples: {
       commonFiles: {
-        scripts: [examplesDependencyPath + 'angular.min.js']
+        scripts: ['../../angular.min.js']
       },
-      dependencyPath: examplesDependencyPath
+      dependencyPath: '../../'
     },
     scripts: [
-      cdnUrl + '/angular.min.js',
-      cdnUrl + '/angular-resource.min.js',
-      cdnUrl + '/angular-route.min.js',
-      cdnUrl + '/angular-cookies.min.js',
-      cdnUrl + '/angular-sanitize.min.js',
-      cdnUrl + '/angular-touch.min.js',
-      cdnUrl + '/angular-animate.min.js',
+      'angular.min.js',
+      'angular-resource.min.js',
+      'angular-route.min.js',
+      'angular-cookies.min.js',
+      'angular-sanitize.min.js',
+      'angular-touch.min.js',
+      'angular-animate.min.js',
       'components/marked-' + getVersion('marked') + '/marked.min.js',
       'js/angular-bootstrap/dropdown-toggle.min.js',
       'components/lunr-' + getVersion('lunr') + '/lunr.min.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/prettify.js',
       'components/google-code-prettify-' + getVersion('google-code-prettify') + '/src/lang-css.js',
       'js/current-version-data.js',
-      'https://code.angularjs.org/snapshot/docs/js/all-versions-data.js',
+      'js/all-versions-data.js',
       'js/pages-data.js',
       'js/nav-data.js',
       'js/docs.min.js'


### PR DESCRIPTION
## Summary
- build docs index using production deployment
- serve all documentation assets from the same origin

## Testing
- `npm run lint`
- `npm run test`
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_b_68c74c6ffbc48321ab0f1ac7fe5d9761